### PR TITLE
Do not provide a feature in features/support/env.el

### DIFF
--- a/features/support/env.el
+++ b/features/support/env.el
@@ -56,6 +56,4 @@
  ;; After when everything has been run
  )
 
-(provide 'env)
-
 ;;; env.el ends here


### PR DESCRIPTION
This is not a library intended to be loaded with `require`, so it
should not advertise itself as such by `provide`ing `env`.  Doing that
would cause conflicts with other packages that use `ecukes`.  This
file is automatically `load`ed by `ecukes-load-support`, defined in
"ecukes-load.el".  Other test related files of a project don't have to
load it explicitly.